### PR TITLE
[FEAT] onlineBadge 컴포넌트 구현

### DIFF
--- a/src/components/OnlineBadge/StyledBadge.ts
+++ b/src/components/OnlineBadge/StyledBadge.ts
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+export const BadgeContainer = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+export const Super = styled.sup<{ isOnline: boolean; isFollowing: boolean }>`
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  font-size: 12px;
+  color: white;
+  border-radius: 20px;
+  background-color: ${({ isOnline }) =>
+    isOnline ? 'var(--Success-300,#b3f17b)' : 'var(--Error-300,#f17b7b)'};
+
+  &.dot {
+    padding: 0;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+
+    border: 3px solid
+      ${({ isFollowing }) =>
+        isFollowing ? 'var(--Primary-200, #e3d4b3)' : 'white'};
+  }
+`;

--- a/src/components/OnlineBadge/index.tsx
+++ b/src/components/OnlineBadge/index.tsx
@@ -1,0 +1,18 @@
+import { BadgeContainer, Super } from './StyledBadge';
+import { PropsWithChildren } from 'react';
+import { OnlineBadgePropsTypes } from '@/types/OnlineBadgePropsTypes';
+
+const OnLineBadge = ({
+  children,
+  isOnline = false,
+  isFollowing = false,
+}: PropsWithChildren<OnlineBadgePropsTypes>) => {
+  return (
+    <BadgeContainer>
+      {children}
+      <Super className='dot' isOnline={isOnline} isFollowing={isFollowing} />
+    </BadgeContainer>
+  );
+};
+
+export default OnLineBadge;

--- a/src/types/OnlineBadgePropsTypes.ts
+++ b/src/types/OnlineBadgePropsTypes.ts
@@ -1,0 +1,4 @@
+export interface OnlineBadgePropsTypes {
+  isOnline: boolean;
+  isFollowing: boolean;
+}


### PR DESCRIPTION
- 온 오프라인 구분 완료
- 팔로잉 여부 구분 완료

색은 기본 색상으로 완료했습니다.!

- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

### Explain
온오프라인, 팔로잉 여부 구분하는 뱃지 를 만들었습니다!
일반 뱃지처럼 아바타를 감싸는 식으로 사용할수있습니다.

### Refer
![화면 캡처 2023-12-27 155423](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/0be06e0d-a8bb-4399-b0e1-9d577b743143)


close #11 
