### PR TITLE
[FEAT] Login page 로직 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,16 @@
+import axios from 'axios';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
-export default function (req: VercelRequest, res: VercelResponse) {}
+export default async function (req: VercelRequest, res: VercelResponse) {
+  const { path = '', method = 'GET', token = '', data } = req.body;
+  const { data: responseValue } = await axios({
+    url: `${process.env.BASE_URL}/${path}`,
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    data,
+  });
+  res.status(200).json(responseValue);
+}

--- a/src/components/Input/InputStyles.ts
+++ b/src/components/Input/InputStyles.ts
@@ -22,10 +22,23 @@ export interface StyledInputProps {
 export const Wrapper = styled.div<WrapperProps>`
   display: ${({ flex }) => (flex ? 'flex' : 'inline-flex')};
   justify-content: center;
+  align-items: center;
+  position: relative;
   width: 100%;
 `;
 
-export const Eye = styled.span``;
+export const Eye = styled.span`
+  display: flex;
+  position: absolute;
+  right: 32%;
+  @media screen and (max-width: 900px) {
+    right: 24%;
+  }
+  @media screen and (max-width: 600px) {
+    right: 6%;
+  }
+  cursor: pointer;
+`;
 
 export const StyledInput = styled.input<StyledInputProps>`
   width: ${({ width }) => (width ? width : 'auto')};

--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -28,8 +28,9 @@ const PasswordInput = ({
         placeholder={placeholder}
         {...props}
       />
-      <Eye onClick={handleEye}>{canSee ? '*' : '&'}</Eye>
-      {/* <Eye className='material-symbols-outlined'>visibility</Eye> */}
+      <Eye onClick={handleEye} className='material-symbols-outlined'>
+        {canSee ? 'visibility_off' : 'visibility'}
+      </Eye>
     </Wrapper>
   );
 };

--- a/src/components/Sign/In.tsx
+++ b/src/components/Sign/In.tsx
@@ -1,8 +1,31 @@
 import { Form, Guide, Register, SignProps } from './SignStyle';
 import Input from '../Input';
 import Button from '../Button';
+import PasswordInput from '../Input/PasswordInput';
+import React, { useState } from 'react';
+import axios from 'axios';
 
 const In = ({ isLogin, setIsLogin }: SignProps) => {
+  const [email, setEmail] = useState('');
+  const [pw, setPW] = useState('');
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const { data } = await axios.post('/api', {
+        path: 'login',
+        method: 'POST',
+        data: {
+          email: email,
+          password: pw,
+        },
+      });
+      localStorage.setItem('auth-token', data.token);
+      alert('로그인 성공');
+    } catch (e) {
+      alert(e);
+    }
+  };
+
   return (
     <Form>
       <Input
@@ -12,14 +35,15 @@ const In = ({ isLogin, setIsLogin }: SignProps) => {
         placeholder='Email'
         autoComplete='on'
         type='email'
+        onChange={(e) => setEmail(e.target.value)}
       />
-      <Input
+      <PasswordInput
         width='360px'
         height='48px'
         fontSize='20px'
         placeholder='Password'
         autoComplete='off'
-        type='password'
+        onChange={(e) => setPW(e.target.value)}
       />
       <Guide>
         노닥노닥이 처음이라면?
@@ -28,7 +52,11 @@ const In = ({ isLogin, setIsLogin }: SignProps) => {
           <span className='material-symbols-outlined'>arrow_forward_ios</span>
         </Register>
       </Guide>
-      <Button size='wide' styleType='primary' event='enabled'>
+      <Button
+        size='wide'
+        styleType='primary'
+        event='enabled'
+        onClick={handleLogin}>
         로그인
       </Button>
     </Form>

--- a/src/components/Sign/Up.tsx
+++ b/src/components/Sign/Up.tsx
@@ -1,8 +1,39 @@
 import { Form, Guide, Register, SignProps } from './SignStyle';
 import Button from '../Button';
 import Input from '../Input';
+import PasswordInput from '../Input/PasswordInput';
+import { useState } from 'react';
+import axios from 'axios';
 
 const Up = ({ isLogin, setIsLogin }: SignProps) => {
+  const [email, setEmail] = useState('');
+  const [pw, setPW] = useState('');
+  const [confirmPW, setConfirmPW] = useState('');
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (pw !== confirmPW) {
+      alert('비밀번호가 다릅니다.');
+      return;
+    }
+
+    try {
+      await axios.post('/api', {
+        path: 'signup',
+        method: 'POST',
+        data: {
+          fullName: 'sonhomin',
+          email: email,
+          password: pw,
+        },
+      });
+      alert('회원가입 성공');
+    } catch (e) {
+      alert(e);
+    }
+  };
+
   return (
     <Form>
       <Input
@@ -12,23 +43,24 @@ const Up = ({ isLogin, setIsLogin }: SignProps) => {
         placeholder='Email'
         autoComplete='on'
         type='email'
+        onChange={(e) => setEmail(e.target.value)}
       />
-      <Input
+      <PasswordInput
         width='360px'
         height='48px'
         fontSize='20px'
         placeholder='Password'
         autoComplete='off'
-        type='password'
+        onChange={(e) => setPW(e.target.value)}
       />
 
-      <Input
+      <PasswordInput
         width='360px'
         height='48px'
         fontSize='20px'
         placeholder='Password'
         autoComplete='off'
-        type='password'
+        onChange={(e) => setConfirmPW(e.target.value)}
       />
 
       <Guide>
@@ -38,7 +70,11 @@ const Up = ({ isLogin, setIsLogin }: SignProps) => {
           <span className='material-symbols-outlined'>arrow_forward_ios</span>
         </Register>
       </Guide>
-      <Button size='wide' styleType='primary' event='enabled'>
+      <Button
+        onClick={handleRegister}
+        size='wide'
+        styleType='primary'
+        event='enabled'>
         가입하기
       </Button>
     </Form>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
+import App from './App.tsx';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/types/ButtonPropsTypes.ts
+++ b/src/types/ButtonPropsTypes.ts
@@ -3,6 +3,5 @@ export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   size?: 'mini' | 'small' | 'regular' | 'wide';
   event?: 'enabled' | 'hover' | 'click' | 'focus' | 'disabled';
   type?: 'button' | 'submit' | 'reset';
-  onClick?: () => void;
   isArrow?: boolean;
 }


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works
- 서버리스 api를 구현하였습니다.
- 로그인/회원가입 로직을 구현하였습니다. 아직 메인 페이지가 없어서 로그인/회원가입의 성공여부는 alert로 판단합니다. 메인페이지가 완성되면 메인페이지로 이동하는식으로 구현할 예정입니다. 비밀번호 틀렸을 경우의 경고도 추 후 구현 예정입니다.
- 비밀번호 가렸다 보였다 하는 기능을 추가하였습니다.


</br>
