### PR TITLE
[FIX] Input component 수정

### DIFF
--- a/src/components/Input/InputStyles.ts
+++ b/src/components/Input/InputStyles.ts
@@ -9,7 +9,8 @@ export interface StyledInputProps {
   width?: string | number;
   height?: string | number;
   fontSize?: string;
-  borderType:
+  $underline?: boolean;
+  $bordertype:
     | 'enabled'
     | 'hover'
     | 'focus'
@@ -44,9 +45,11 @@ export const StyledInput = styled.input<StyledInputProps>`
   width: ${({ width }) => (width ? width : 'auto')};
   height: ${({ height }) => (height ? height : 'auto')};
   font-size: ${({ fontSize }) => (fontSize ? fontSize : 'auto')};
+  border: 1px solid ${({ $bordertype }) => borderMap[$bordertype]};
+  border-top: ${({ $underline }) => ($underline ? 'none' : 'auto')};
+  border-left: ${({ $underline }) => ($underline ? 'none' : 'auto')};
+  border-right: ${({ $underline }) => ($underline ? 'none' : 'auto')};
   padding: 4px 8px;
-  border: 1px solid ${({ bordertype }) => borderMap[bordertype]};
-  border-radius: 4px;
   box-sizing: border-box;
   background-color: #f9f9f9;
 `;

--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { InputProps } from '@/types/InputProps';
 
 const PasswordInput = ({
-  flex = false,
-  borderType = 'filled',
+  $flex = false,
+  $bordertype = 'filled',
   required = false,
   disabled = false,
   readOnly = false,
@@ -18,9 +18,9 @@ const PasswordInput = ({
   };
 
   return (
-    <Wrapper flex={flex} {...wrapperProps}>
+    <Wrapper $flex={$flex} {...wrapperProps}>
       <StyledInput
-        borderType={borderType}
+        $bordertype={$bordertype}
         required={required}
         disabled={disabled}
         readOnly={readOnly}

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -3,7 +3,8 @@ import { InputProps } from '@/types/InputProps';
 
 const Input = ({
   $flex = false,
-  bordertype = 'filled',
+  $bordertype = 'filled',
+  $underline = false,
   required = false,
   disabled = false,
   readOnly = false,
@@ -14,7 +15,8 @@ const Input = ({
   return (
     <Wrapper $flex={$flex} {...wrapperProps}>
       <StyledInput
-        bordertype={bordertype}
+        $bordertype={$bordertype}
+        $underline={$underline}
         required={required}
         disabled={disabled}
         readOnly={readOnly}

--- a/src/components/PostComment/index.tsx
+++ b/src/components/PostComment/index.tsx
@@ -33,7 +33,7 @@ const PostComment = () => {
           }}>
           <Input
             flex={false}
-            borderType='filled'
+            $bordertype='filled'
             placeholder='플레이스 홀더 텍스트'
             width='588px'
             height='48px'

--- a/src/components/PostVote/index.tsx
+++ b/src/components/PostVote/index.tsx
@@ -30,25 +30,25 @@ const PostVote = () => {
       </VoteTitleWrapper>
       <Input
         placeholder='투표 후보 1'
-        borderType='enabled'
+        $bordertype='enabled'
         width='466px'
         height='48px'
       />
       <Input
         placeholder='투표 후보 2'
-        borderType='enabled'
+        $bordertype='enabled'
         width='466px'
         height='48px'
       />
       <Input
         placeholder='투표 후보 3'
-        borderType='enabled'
+        $bordertype='enabled'
         width='466px'
         height='48px'
       />
       <Input
         placeholder='투표 후보 4'
-        borderType='enabled'
+        $bordertype='enabled'
         width='466px'
         height='48px'
       />

--- a/src/components/Sign/In.tsx
+++ b/src/components/Sign/In.tsx
@@ -1,4 +1,4 @@
-import { Form, Guide, Register, SignProps } from './SignStyle';
+import { Form, Guide, Register, SignProps, Warning } from './SignStyle';
 import Input from '../Input';
 import Button from '../Button';
 import PasswordInput from '../Input/PasswordInput';
@@ -8,6 +8,8 @@ import axios from 'axios';
 const In = ({ isLogin, setIsLogin }: SignProps) => {
   const [email, setEmail] = useState('');
   const [pw, setPW] = useState('');
+  const [warn, setWarn] = useState(false);
+  const [warnText, setWarnText] = useState('');
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
@@ -22,7 +24,12 @@ const In = ({ isLogin, setIsLogin }: SignProps) => {
       localStorage.setItem('auth-token', data.token);
       alert('로그인 성공');
     } catch (e) {
-      alert(e);
+      setWarnText('아이디 또는 비밀번호가 일치하지 않습니다.');
+      setWarn(true);
+      setTimeout(() => {
+        setWarn(false);
+        setWarnText('');
+      }, 3000);
     }
   };
 
@@ -35,6 +42,7 @@ const In = ({ isLogin, setIsLogin }: SignProps) => {
         placeholder='Email'
         autoComplete='on'
         type='email'
+        $bordertype={warn ? 'error' : 'filled'}
         onChange={(e) => setEmail(e.target.value)}
       />
       <PasswordInput
@@ -43,8 +51,10 @@ const In = ({ isLogin, setIsLogin }: SignProps) => {
         fontSize='20px'
         placeholder='Password'
         autoComplete='off'
+        $bordertype={warn ? 'error' : 'filled'}
         onChange={(e) => setPW(e.target.value)}
       />
+      {warn ? <Warning>{warnText}</Warning> : ''}
       <Guide>
         노닥노닥이 처음이라면?
         <Register onClick={() => setIsLogin(!isLogin)}>

--- a/src/components/Sign/SignStyle.ts
+++ b/src/components/Sign/SignStyle.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from '@/styles/theme';
 
 export const Content = styled.div`
   display: flex;
@@ -12,6 +13,12 @@ export const Form = styled.form`
   flex-direction: column;
   align-items: center;
   gap: 16px;
+`;
+
+export const Warning = styled.div`
+  display: flex;
+  color: ${theme.colors.error[500]};
+  margin-left: 48px;
 `;
 
 export const Guide = styled.span`

--- a/src/components/Sign/Up.tsx
+++ b/src/components/Sign/Up.tsx
@@ -1,4 +1,4 @@
-import { Form, Guide, Register, SignProps } from './SignStyle';
+import { Form, Guide, Register, SignProps, Warning } from './SignStyle';
 import Button from '../Button';
 import Input from '../Input';
 import PasswordInput from '../Input/PasswordInput';
@@ -9,12 +9,18 @@ const Up = ({ isLogin, setIsLogin }: SignProps) => {
   const [email, setEmail] = useState('');
   const [pw, setPW] = useState('');
   const [confirmPW, setConfirmPW] = useState('');
-
+  const [pwWarn, setPwWarn] = useState(false);
+  const [warnText, setWarnText] = useState('');
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (pw !== confirmPW) {
-      alert('비밀번호가 다릅니다.');
+      setWarnText('비밀번호가 일치하지 않습니다.');
+      setPwWarn(true);
+      setTimeout(() => {
+        setPwWarn(false);
+        setWarnText('');
+      }, 3000);
       return;
     }
 
@@ -51,6 +57,7 @@ const Up = ({ isLogin, setIsLogin }: SignProps) => {
         fontSize='20px'
         placeholder='Password'
         autoComplete='off'
+        $bordertype={pwWarn ? 'error' : 'filled'}
         onChange={(e) => setPW(e.target.value)}
       />
 
@@ -60,9 +67,10 @@ const Up = ({ isLogin, setIsLogin }: SignProps) => {
         fontSize='20px'
         placeholder='Password'
         autoComplete='off'
+        $bordertype={pwWarn ? 'error' : 'filled'}
         onChange={(e) => setConfirmPW(e.target.value)}
       />
-
+      {pwWarn ? <Warning>{warnText}</Warning> : ''}
       <Guide>
         이미 노닥노닥과 함께라면
         <Register onClick={() => setIsLogin(!isLogin)}>

--- a/src/types/InputProps.ts
+++ b/src/types/InputProps.ts
@@ -4,9 +4,9 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   $flex?: boolean;
   wrapperProps?: WrapperProps;
-  hint?: string;
   fontSize?: string;
-  borderType?:
+  $underline?: boolean;
+  $bordertype?:
     | 'enabled'
     | 'hover'
     | 'focus'


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works
- input component의 bordertype에러를 수정하였습니다. 
- input의 border-radius를 제거 하였습니다.
- underline props를 추가하여 아래만 border가 있는 input을 사용할 수 있게 하였습니다.
- 로그인, 회원가입 할 때 잘못된 입력(잘못된 email, pw)에 대한 경고를 추가하였습니다. 이는 hint와 같은 기능으로 input props의 hint는 삭제하였습니다.
- 해줘야할 예외처리가 아직 많지만 이것은 시간관계상 serverless function에 대해 좀 더 알아보고 해야할거 같아서 추후 작업으로 미루어두었습니다.


### Refer
![image](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/96977881/fbaeaee6-ab83-47da-93c8-e647b6a18680)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/96977881/8f0e55ed-f5cd-4591-a13c-bd6f376c92f7)

잘못된 입력시 그림과 같이 input border를 붉게 처리하고 텍스트를 띄웁니다. 해당 효과는 3초 후 사라집니다.