### PR TITLE
[FEAT] detailPage props수정 및 리덕스 store체계 변경

### DIFF
--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -45,7 +45,7 @@ const CommentItem = ({ author, createdAt, comment }: Comment) => {
         </div>
       </div>
       <Text tagType='span' fontType='body3' colorType='black'>
-        {content}
+        {content.content}
       </Text>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import Index from './pages/Index.tsx';
 import Login from './pages/Login.tsx';
 import NotFound from './pages/NotFound.tsx';
 import PostEditPage from './pages/PostEditPage';
+import DetailPage from './pages/DetailPage';
 import Main from './pages/mainPage';
 import UserPage from './pages/userPage/index.tsx';
 import store from './store';
@@ -16,6 +17,7 @@ const router = createBrowserRouter([
   { path: '/write', element: <PostEditPage /> },
   { path: '/home', element: <Main /> },
   { path: '/user', element: <UserPage /> },
+  { path: '/detail', element: <DetailPage /> },
 ]);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/pages/DetailPage/PostComment/index.tsx
+++ b/src/pages/DetailPage/PostComment/index.tsx
@@ -1,10 +1,16 @@
 import { dummyPost } from '../Dummy';
+import { useSelector } from 'react-redux';
 import CommentItem from '@/components/Comment';
 import theme from '@/styles/theme';
 import Input from '@/components/Input';
 import Button from '@/components/Button';
+import { RootState } from '@/store';
 
 const PostComment = () => {
+  const postDetailComment = useSelector(
+    (state: RootState) => state.postDetail.post.comments,
+  );
+
   return (
     <div
       style={{
@@ -22,7 +28,8 @@ const PostComment = () => {
             author={comment.author}
             createdAt={comment.createdAt}
             comment={comment.comment}
-            key={index}></CommentItem>
+            key={index}
+          />
         ))}
         <div
           className='userInput'

--- a/src/pages/DetailPage/PostContent/index.tsx
+++ b/src/pages/DetailPage/PostContent/index.tsx
@@ -3,12 +3,23 @@ import {
   PostContentAuthorWrapper,
 } from './PostContentStyled';
 import { dummyPost } from './../Dummy';
+import { useSelector } from 'react-redux';
 import Text from '@/components/Text';
 import Avatar from '@/components/Avatar';
 import Image from '@/components/Image';
+import { RootState } from '@/store';
 
 const PostContent = () => {
   const { title, content } = JSON.parse(dummyPost.title);
+
+  const postDetailContent = useSelector(
+    (state: RootState) => state.postDetail.post,
+  );
+  const postDetailAuthor = useSelector(
+    (state: RootState) => state.postDetail.post.author,
+  );
+
+  if (!postDetailContent.title) return null;
 
   return (
     <PostContentWrapper className='ContentTitle'>

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -1,8 +1,16 @@
-import PostComment from './PostComment';
-import PostVote from './PostVote';
 import PostContent from './PostContent';
+import PostVote from './PostVote';
+import PostComment from './PostComment';
+import { useEffect } from 'react';
+import { useDispatch } from '@/store';
+import { getPostDetail } from '@/slices/postDetail';
 
 const DetailPage = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getPostDetail());
+  }, []);
+
   return (
     <div
       style={{

--- a/src/pages/mainPage/index.tsx
+++ b/src/pages/mainPage/index.tsx
@@ -2,6 +2,7 @@ import { MainWrapper, PostContentWrapper, MainFlexWrapper } from './StyledMain';
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+
 import PostCard from '@/components/PostCard';
 import Pagination from '@/components/Pagination';
 import UserListCard from '@/components/UserListCard';
@@ -28,7 +29,6 @@ const Main = () => {
 
   const handlePageChange = (page: number) => {
     if (page < 1 || page > totalPage) return;
-
     setPage(page);
   };
 

--- a/src/slices/postDetail.ts
+++ b/src/slices/postDetail.ts
@@ -1,0 +1,45 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+import { Post } from '@/types/APIResponseTypes';
+
+interface DetailPost {
+  post: Post;
+  isLoading: boolean;
+}
+
+const initialState: DetailPost = {
+  post: {} as Post,
+  isLoading: false,
+};
+
+export const getPostDetail = createAsyncThunk(
+  'channel/getChannel',
+  async () => {
+    const response = await axios({
+      url: 'https://kdt.frontend.5th.programmers.co.kr:5003/posts/6592c80a2a48542ca963b86d',
+      method: 'get',
+    });
+
+    return response.data;
+  },
+);
+
+export const detailPostSlice = createSlice({
+  name: 'detailPost',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(getPostDetail.pending, (state) => {
+      state.isLoading = true;
+    });
+    builder.addCase(getPostDetail.fulfilled, (state, action) => {
+      state.post = action.payload;
+      state.isLoading = false;
+    });
+    builder.addCase(getPostDetail.rejected, (state) => {
+      state.isLoading = false;
+    });
+  },
+});
+
+export default detailPostSlice.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,10 @@
 import { useDispatch as reduxUseDispatch } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import channelReducer from '@/slices/channel';
+import postDetailReducer from '@/slices/postDetail';
 
 const store = configureStore({
-  reducer: { channel: channelReducer },
+  reducer: { channel: channelReducer, postDetail: postDetailReducer },
 });
 type AppDispatch = typeof store.dispatch;
 export const useDispatch = () => reduxUseDispatch<AppDispatch>();


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.


### Explain
1. getDetailPage를 통해 게시글 상세보기 api 를 조회해 데이터를 store에 저장
2. 각 컴포넌트에서 Selector를 통해 데이터 추출
3. 코드 부분오류 해결
4. 목업데이터 현상유지 추후 변경 예정

### add more
1. 목업데이터 모두 삭제하고 실질적 데이터로 변경
2. 현재 API 구조를 바꾸지못해 특정 하나의 게시글에 대한 요청만 존재함, 추후 post_id 를 주입해 api를 변경해야 됨
3. 리렌더링이 너무많이 발생해서 일단 구현이 마무리되고 동작을 명확하게 하면 수정할 예정임


</br>

close #70
