### PR TITLE
[FEAT] 채널 데이터와 home 페이지 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,23 @@
 import Footer from './components/Footer';
 import Header from './components/Header';
-import { mockChannels } from './components/Header/mockChannels';
 import { mockUsers } from './components/UserListCard/mockUsers';
+import { getChannel } from './slices/channel';
+import { useDispatch, RootState } from './store';
 import { Outlet } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
 
 const App = () => {
+  const channels = useSelector((state: RootState) => state.channel.channels);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getChannel());
+  }, [dispatch]);
   return (
     <>
       <Header
-        channels={mockChannels}
+        channels={channels}
         isAuth={!!localStorage.getItem('auth-token')}
         userImage={mockUsers[0].image}
       />

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -10,11 +10,13 @@ import Button from '../Button';
 import Avatar from '../Avatar';
 import Badge from '../Badge';
 import LogoWithFontSize from '../LogoWithFontSize';
-import Notification from '../Notification';
+// import Notification from '../Notification';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, NavLink } from 'react-router-dom';
 import Bell from '@/assets/Bell';
 import Card from '@/components/Card';
+import { useDispatch } from '@/store';
+import { setChannel } from '@/slices/channel';
 
 const tempCount = 100000;
 
@@ -22,6 +24,11 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
   const [seen, setSeen] = useState(false);
   const count = seen ? 0 : tempCount;
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const handleClick = (id: string) => () => {
+    dispatch(setChannel(id));
+  };
 
   return (
     <Card
@@ -34,9 +41,14 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
         </LogoWrapper>
         <ChannelWrapper>
           {channels.map((channel) => (
-            <Text key={channel._id} tagType='span' fontType='h4'>
-              {channel.name}
-            </Text>
+            <NavLink
+              key={channel._id}
+              to='home'
+              onClick={handleClick(channel._id)}>
+              <Text key={channel._id} tagType='span' fontType='h4'>
+                {channel.name}
+              </Text>
+            </NavLink>
           ))}
         </ChannelWrapper>
         {isAuth ? (
@@ -44,7 +56,7 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
             <Badge count={count}>
               <Bell handleSeen={() => setSeen(true)} />
             </Badge>
-            <Notification />
+            {/* <Notification /> */}
             <Avatar size='small' src={userImage} />
           </AuthUiWrapper>
         ) : (

--- a/src/components/PostCard/PostSnippet.tsx
+++ b/src/components/PostCard/PostSnippet.tsx
@@ -1,10 +1,9 @@
 import { PostSnippetBox } from './StyledPostCard';
+import { PostSnippetProps } from './PostCardTypes';
 import { UserSnippetBox } from '../UserSnippet/StyledUserSnippet';
 import Avatar from '../Avatar';
 import Image from '../Image';
 import Text from '../Text';
-
-import { PostSnippetProps } from '@/types/PostCardTypes';
 
 const PostSnippet = ({
   avatar,
@@ -15,15 +14,9 @@ const PostSnippet = ({
 }: PostSnippetProps) => {
   return (
     <PostSnippetBox>
-      <Image
-        width='280px'
-        height='146px'
-        block={true}
-        src={image}
-        mode='cover'
-      />
+      <Image width='280px' height='146px' src={image} />
       <div>
-        <Text fontType='body2' colorType='black' style={{ fontWeight: '700' }}>
+        <Text tagType='p' fontType='body2' colorType='black'>
           {title}
         </Text>
         <Text tagType='span' fontType='caption' colorType='black'>
@@ -42,7 +35,7 @@ const PostSnippet = ({
       </div>
       <UserSnippetBox>
         <Avatar size='mini' src={avatar} />
-        <Text fontType='caption' colorType='black'>
+        <Text tagType='span' fontType='caption' colorType='black'>
           {fullName}
         </Text>
       </UserSnippetBox>

--- a/src/pages/mainPage/index.tsx
+++ b/src/pages/mainPage/index.tsx
@@ -1,8 +1,7 @@
 import { MainWrapper, PostContentWrapper, MainFlexWrapper } from './StyledMain';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-
 import PostCard from '@/components/PostCard';
 import Pagination from '@/components/Pagination';
 import UserListCard from '@/components/UserListCard';
@@ -11,21 +10,21 @@ import { mockUsers } from '@/components/UserListCard/mockUsers';
 import Text from '@/components/Text';
 import Button from '@/components/Button';
 import { TempPost } from '@/components/PostCard/PostCardTypes';
-import { RootState, useDispatch } from '@/store';
-import Header from '@/components/Header';
-import { getChannel } from '@/slices/channel';
-
-const MockTitle = '연예';
+import { RootState } from '@/store';
 
 const Main = () => {
   const [page, setPage] = useState(1);
   const navigate = useNavigate();
-  const dispatch = useDispatch();
+  const channel = useSelector(
+    (state: RootState) => state.channel.currentChannel,
+  );
+  const channelLoading = useSelector(
+    (state: RootState) => state.channel.isLoading,
+  );
+
   const limit = 12;
   const posts: TempPost[] = mockPosts.slice((page - 1) * limit, page * limit);
   const totalPage = Math.ceil(mockPosts.length / limit);
-
-  const channels = useSelector((state: RootState) => state.channel.channels);
 
   const handlePageChange = (page: number) => {
     if (page < 1 || page > totalPage) return;
@@ -42,22 +41,13 @@ const Main = () => {
     navigate('/write');
   };
 
-  useEffect(() => {
-    dispatch(getChannel());
-  }, []);
-
   return (
     <>
-      <Header
-        channels={channels}
-        isAuth={true}
-        userImage={mockUsers[0].image}
-      />
       <MainWrapper>
         <PostContentWrapper>
           <MainFlexWrapper>
             <Text tagType='span' fontType='h2'>
-              {`${MockTitle} 채널`}
+              {!channelLoading && channel ? `${channel.name} 채널` : '채널'}
             </Text>
             <Button styleType='ghost' size='small' onClick={handleWriteClick}>
               글 쓰기

--- a/src/slices/channel.ts
+++ b/src/slices/channel.ts
@@ -39,7 +39,10 @@ export const channelSlice = createSlice({
       state.isLoading = true;
     });
     builder.addCase(getChannel.fulfilled, (state, action) => {
-      state.channels = action.payload;
+      state.channels = action.payload.filter(
+        (channel: Channel) =>
+          !['연예', '잡담', '스포츠'].includes(channel.name),
+      );
       state.currentChannel = action.payload[0];
       state.isLoading = false;
     });


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works

### Explain
채널 데이터를 home 페이지와 연결
- 헤더의 채널들을 실제 데이터로 교체
- 헤더의 채널들 클릭시 home 으로 이동

### Refer
<img width="1433" alt="스크린샷 2024-01-02 오후 5 56 34" src="https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/89655ddf-7520-4443-abb5-dac9b3e35a58">



closes #85 
