### PR TITLE
[FEAT] 유저 팔로워, home 에서 나가는 라우팅 구현

### DIFF
--- a/src/components/PostCard/PostCardTypes.ts
+++ b/src/components/PostCard/PostCardTypes.ts
@@ -5,6 +5,7 @@ export interface PostSnippet {
   image?: string;
   title: string;
   count: string;
+  userId: string;
 }
 
 export interface PostCardProps {
@@ -16,5 +17,6 @@ export interface PostSnippetProps {
   image?: string;
   title: string;
   count: string;
-  fullName: string;
+  fullName?: string;
+  userId?: string;
 }

--- a/src/components/PostCard/PostSnippet.tsx
+++ b/src/components/PostCard/PostSnippet.tsx
@@ -4,6 +4,7 @@ import { UserSnippetBox } from '../UserSnippet/StyledUserSnippet';
 import Avatar from '../Avatar';
 import Image from '../Image';
 import Text from '../Text';
+import { useNavigate } from 'react-router-dom';
 
 const PostSnippet = ({
   avatar,
@@ -11,7 +12,13 @@ const PostSnippet = ({
   title,
   count,
   fullName,
+  userId,
 }: PostSnippetProps) => {
+  const navigate = useNavigate();
+  const handleUserClick = () => {
+    navigate(`/user/${userId}`);
+  };
+
   return (
     <PostSnippetBox>
       <Image width='280px' height='146px' src={image} />
@@ -33,10 +40,10 @@ const PostSnippet = ({
           명 투표
         </Text>
       </div>
-      <UserSnippetBox>
+      <UserSnippetBox onClick={handleUserClick}>
         <Avatar size='mini' src={avatar} />
         <Text tagType='span' fontType='caption' colorType='black'>
-          {fullName}
+          {fullName ? fullName : 'loading...'}
         </Text>
       </UserSnippetBox>
     </PostSnippetBox>

--- a/src/components/PostCard/index.tsx
+++ b/src/components/PostCard/index.tsx
@@ -4,9 +4,30 @@ import { PostCardProps } from './PostCardTypes';
 import Button from '../Button';
 import Card from '../Card';
 import styled from 'styled-components';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
+
+import {
+  useSelectedChannel,
+  useSelectedChannelLoading,
+} from '@/hooks/useSelectedChannel';
 
 const PostCard = ({ post }: PostCardProps) => {
-  const { avatar, image, title, count, fullName } = post;
+  const { avatar, image, title, count, fullName, userId } = post;
+  const channel = useSelectedChannel();
+  const channelLoading = useSelectedChannelLoading();
+  const currentUser = useSelector(
+    (state: RootState) => state.userInfo.currentUser,
+  );
+  const location = useLocation();
+  const isUserPage = location.pathname.startsWith('/user');
+
+  const navigate = useNavigate();
+
+  const handleDetailClick = () => {
+    navigate(`/detail/${channel?._id}/${post._id}`);
+  };
 
   return (
     <Card width='280px' height='280px' shadowType='medium'>
@@ -15,11 +36,22 @@ const PostCard = ({ post }: PostCardProps) => {
         image={image}
         title={title}
         count={count}
-        fullName={fullName}
+        fullName={isUserPage ? currentUser?.fullName : fullName}
+        userId={isUserPage ? currentUser?._id : userId}
       />
       <FlexWrapper>
-        <Button styleType='primary'>자세히 보기</Button>
-        <Button styleType='ghost'>결과 보기</Button>
+        <Button
+          styleType='primary'
+          event={channelLoading ? 'disabled' : 'enabled'}
+          onClick={handleDetailClick}>
+          자세히 보기
+        </Button>
+        <Button
+          styleType='ghost'
+          event={channelLoading ? 'disabled' : 'enabled'}
+          onClick={handleDetailClick}>
+          결과 보기
+        </Button>
       </FlexWrapper>
     </Card>
   );

--- a/src/components/UserListCard/index.tsx
+++ b/src/components/UserListCard/index.tsx
@@ -15,6 +15,7 @@ const UserListCard = ({ users }: UserListCardProps) => {
           image={user.image}
           isFollowing={user.isFollowing}
           isOnline={user.isOnline}
+          userId={user._id}
           key={user._id}
         />
       ))}

--- a/src/components/UserSnippet/StyledUserSnippet.ts
+++ b/src/components/UserSnippet/StyledUserSnippet.ts
@@ -8,6 +8,8 @@ export const UserSnippetBox = styled.div`
   position: relative;
 
   margin: 4px 0;
+
+  cursor: pointer;
 `;
 export const Title = styled.h2`
   position: -webkit-sticky;

--- a/src/components/UserSnippet/UserSnippetProps.ts
+++ b/src/components/UserSnippet/UserSnippetProps.ts
@@ -3,6 +3,7 @@ export interface UserSnippetProps {
   isOnline: boolean;
   isFollowing: boolean;
   image: string;
+  userId: string;
 }
 
 export interface UserSnippetGroupProps {

--- a/src/components/UserSnippet/index.tsx
+++ b/src/components/UserSnippet/index.tsx
@@ -3,15 +3,22 @@ import { UserSnippetProps, UserSnippetGroupProps } from './UserSnippetProps';
 import Avatar from '../Avatar';
 import OnLineBadge from '../OnlineBadge';
 import { PropsWithChildren } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const UserSnippet = ({
   isOnline,
   image,
   fullName,
   isFollowing,
+  userId,
 }: UserSnippetProps) => {
+  const navigate = useNavigate();
+  const handleUserClick = () => {
+    navigate(`/user/${userId}`);
+  };
+
   return (
-    <UserSnippetBox>
+    <UserSnippetBox onClick={handleUserClick}>
       <OnLineBadge isOnline={isOnline} isFollowing={isFollowing}>
         <Avatar src={image} alt={fullName} size='small' />
       </OnLineBadge>

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,14 +1,13 @@
 import { useState } from 'react';
-import { postListToPostSnippetList } from '@/slices/postList/utils';
-import { Post } from '@/types/APIResponseTypes';
 import { PostSnippet } from '@/components/PostCard/PostCardTypes';
 
-export const usePagination = (postList: Post[], limit: number = 12) => {
+export const usePagination = (postList: PostSnippet[], limit: number = 12) => {
   const [page, setPage] = useState(1);
 
-  const paginationedPostList: PostSnippet[] = postListToPostSnippetList(
-    postList,
-  ).slice((page - 1) * limit, page * limit);
+  const paginationedPostList: PostSnippet[] = postList.slice(
+    (page - 1) * limit,
+    page * limit,
+  );
 
   const totalPage = Math.ceil(paginationedPostList.length / limit);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,9 +22,9 @@ const router = createBrowserRouter([
     children: [
       { path: '/write', element: <PostEditPage mode='create' /> },
       { path: '/home', element: <Main /> },
-      { path: '/user', element: <UserPage /> },
-      { path: '/user/setting', element: <Setting /> },
-      { path: '/detail', element: <DetailPage /> },
+      { path: '/user/:userId', element: <UserPage /> },
+      { path: '/user/:userId/setting', element: <Setting /> },
+      { path: '/detail/:channelId/:postId', element: <DetailPage /> },
     ],
   },
   { path: '/sign', element: <Login /> },

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -2,13 +2,16 @@ import PostContent from './PostContent';
 import PostVote from './PostVote';
 import PostComment from './PostComment';
 import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { useDispatch } from '@/store';
 import { getPostDetail } from '@/slices/postDetail';
 
 const DetailPage = () => {
   const dispatch = useDispatch();
+  const { postId } = useParams();
+
   useEffect(() => {
-    dispatch(getPostDetail());
+    dispatch(getPostDetail({ postId }));
   }, []);
 
   return (

--- a/src/pages/mainPage/index.tsx
+++ b/src/pages/mainPage/index.tsx
@@ -1,12 +1,13 @@
 import { MainWrapper, PostContentWrapper, MainFlexWrapper } from './StyledMain';
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import PostCard from '@/components/PostCard';
 import Pagination from '@/components/Pagination';
 import UserListCard from '@/components/UserListCard';
 import Text from '@/components/Text';
 import Button from '@/components/Button';
-import { useDispatch } from '@/store';
+import { RootState, useDispatch } from '@/store';
 import { getPostListByChannelId } from '@/slices/postList/thunks';
 import { getUserList } from '@/slices/userList/thunk';
 import { useSelectedPostList } from '@/hooks/useSelectedPostList';
@@ -18,6 +19,9 @@ import { useSelectedUserList } from '@/hooks/useSelectedUserList';
 // import useInterval from '@/hooks/useInterval'; // polling 방식 , 너무 많은 요청이 갈까봐 주석처리
 import { userListToUserSnippetList } from '@/slices/userList/utils';
 import { usePagination } from '@/hooks/usePagination';
+import { getMyInfo } from '@/slices/user';
+
+import { postListToPostSnippetList } from '@/slices/postList/utils';
 
 const Main = () => {
   const navigate = useNavigate();
@@ -27,7 +31,8 @@ const Main = () => {
   const channel = useSelectedChannel();
   const channelLoading = useSelectedChannelLoading();
   const { paginationedPostList, totalPage, currentPage, handlePageChange } =
-    usePagination(useSelectedPostList());
+    usePagination(postListToPostSnippetList(useSelectedPostList()));
+  const myInfo = useSelector((state: RootState) => state.userInfo.authUser);
 
   const handleWriteClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -52,6 +57,16 @@ const Main = () => {
   // useInterval(() => {
   //   dispatch(getUserList());
   // }, 6000);
+
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token');
+    if (!token) {
+      alert('로그인이 필요한 서비스 입니다.');
+      navigate('/sign');
+    } else {
+      dispatch(getMyInfo({ token }));
+    }
+  }, [navigate, dispatch]);
 
   return (
     <>
@@ -78,7 +93,7 @@ const Main = () => {
             handlePageChange={handlePageChange}
           />
         </PostContentWrapper>
-        <UserListCard users={userListToUserSnippetList(userList)} />
+        <UserListCard users={userListToUserSnippetList(userList, myInfo)} />
       </MainWrapper>
     </>
   );

--- a/src/pages/userPage/UserPostList.tsx
+++ b/src/pages/userPage/UserPostList.tsx
@@ -1,14 +1,18 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import Text from '@/components/Text';
 import { RootState, useDispatch } from '@/store';
 import { getUser } from '@/slices/user';
 import PostCard from '@/components/PostCard';
+import { postListToPostSnippetList } from '@/slices/postList/utils';
 
 const UserPostList = () => {
   const dispatch = useDispatch();
+  const { userId } = useParams();
   useEffect(() => {
-    dispatch(getUser());
+    if (!userId) return;
+    dispatch(getUser({ userId }));
   }, []);
 
   const currentUser = useSelector(
@@ -18,6 +22,7 @@ const UserPostList = () => {
     return <></>;
   }
   const { fullName, posts } = currentUser;
+  const postSnippetList = postListToPostSnippetList(posts);
 
   return (
     <>
@@ -32,20 +37,8 @@ const UserPostList = () => {
         님의 게시글 목록
       </Text>
       <PostCard.Group>
-        {posts.map((post) => {
-          return (
-            <PostCard
-              key={post._id}
-              post={{
-                title: JSON.parse(post.title).title,
-                fullName: '',
-                avatar: '',
-                _id: '',
-                image: '',
-                count: '',
-              }}
-            />
-          );
+        {postSnippetList.map((post) => {
+          return <PostCard key={post._id} post={post} />;
         })}
       </PostCard.Group>
     </>

--- a/src/slices/postDetail.ts
+++ b/src/slices/postDetail.ts
@@ -12,11 +12,14 @@ const initialState: DetailPost = {
   isLoading: false,
 };
 
+interface PostId {
+  postId: string | undefined;
+}
 export const getPostDetail = createAsyncThunk(
   'detailPost/getPostDetail',
-  async () => {
+  async ({ postId }: PostId) => {
     const response = await axios({
-      url: 'https://kdt.frontend.5th.programmers.co.kr:5003/posts/6592c80a2a48542ca963b86d',
+      url: `https://kdt.frontend.5th.programmers.co.kr:5003/posts/${postId}`,
       method: 'get',
     });
 

--- a/src/slices/postList/utils.ts
+++ b/src/slices/postList/utils.ts
@@ -5,6 +5,7 @@ export const postListToPostSnippetList = (postList: Post[]): PostSnippet[] =>
   postList.map(({ author, _id, image, title, comments }) => ({
     fullName: author.fullName,
     avatar: author.image,
+    userId: author._id,
     _id,
     image,
     title: JSON.parse(title).title,

--- a/src/slices/user.ts
+++ b/src/slices/user.ts
@@ -4,22 +4,42 @@ import { User } from '@/types/APIResponseTypes';
 
 interface UserInfo {
   currentUser: User | undefined;
+  authUser: User | undefined;
   isLoading: boolean;
 }
 
 const initialState: UserInfo = {
   currentUser: undefined,
+  authUser: undefined,
   isLoading: false,
 };
 
-export const getUser = createAsyncThunk('user/getUser', async () => {
-  const response = await axios({
-    url: 'https://kdt.frontend.5th.programmers.co.kr:5003/users/65870847b035721f23358062',
-    method: 'get',
-  });
+export const getUser = createAsyncThunk(
+  'user/getUser',
+  async ({ userId }: { userId: string }) => {
+    const response = await axios({
+      url: `https://kdt.frontend.5th.programmers.co.kr:5003/users/${userId}`,
+      method: 'get',
+    });
 
-  return response.data;
-});
+    return response.data;
+  },
+);
+
+export const getMyInfo = createAsyncThunk(
+  'user/getMyInfo',
+  async ({ token }: { token: string }) => {
+    const response = await axios({
+      url: `https://kdt.frontend.5th.programmers.co.kr:5003/auth-user`,
+      method: 'get',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return response.data;
+  },
+);
 
 export const userInfo = createSlice({
   name: 'user',
@@ -34,6 +54,16 @@ export const userInfo = createSlice({
       state.isLoading = false;
     });
     builder.addCase(getUser.rejected, (state) => {
+      state.isLoading = false;
+    });
+    builder.addCase(getMyInfo.pending, (state) => {
+      state.isLoading = true;
+    });
+    builder.addCase(getMyInfo.fulfilled, (state, action) => {
+      state.authUser = action.payload;
+      state.isLoading = false;
+    });
+    builder.addCase(getMyInfo.rejected, (state) => {
       state.isLoading = false;
     });
   },

--- a/src/slices/userList/utils.ts
+++ b/src/slices/userList/utils.ts
@@ -1,11 +1,16 @@
 import { User } from '@/types/APIResponseTypes';
 import { UserSnippet } from '@/components/UserListCard/UserListCardTypes';
 
-export const userListToUserSnippetList = (userList: User[]): UserSnippet[] =>
+export const userListToUserSnippetList = (
+  userList: User[],
+  myInfo?: User,
+): UserSnippet[] =>
   userList.map(({ _id, fullName, image, isOnline }) => ({
     _id,
     fullName,
     isOnline,
-    isFollowing: false,
+    isFollowing: myInfo
+      ? myInfo.following.some(({ user }) => user === _id)
+      : false,
     image,
   }));


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works
### Explain

유저 팔로워 출력 구현 및 라우팅 구현

- 유저 팔로워 출력
- home 에서 나가는 라우팅 구현
### Refer
![화면 캡처 2024-01-04 095559](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/737d9b7c-e620-4919-abc2-348d058a0387)
![화면 캡처 2024-01-04 095614](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/8c12236a-c3f5-4144-8058-6b9f04acebf2)
![화면 캡처 2024-01-04 095626](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/11cebd34-8d6d-40fb-89cf-83f6c143b8c8)


close #97 
