### PR TITLE
[FEAT] index 라우팅 수정, detail 페이지기능 추가

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -57,6 +57,10 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
     setFocus(!focus);
   });
 
+  const handleLogin = () => {
+    navigate('/sign');
+  };
+
   return (
     <Card
       width='100vw'
@@ -111,7 +115,7 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
             <Avatar size='small' src={userImage} />
           </AuthUiWrapper>
         ) : (
-          <Button styleType='primary' size='small'>
+          <Button styleType='primary' size='small' onClick={handleLogin}>
             로그인
           </Button>
         )}

--- a/src/pages/DetailPage/PostComment/StyledPostComment.ts
+++ b/src/pages/DetailPage/PostComment/StyledPostComment.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const FlexColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  align-items: flex-start;
+  justify-content: flex-start;
+
+  gap: 16px;
+
+  > * {
+    margin: 0;
+  }
+`;

--- a/src/pages/DetailPage/PostComment/index.tsx
+++ b/src/pages/DetailPage/PostComment/index.tsx
@@ -24,6 +24,11 @@ const PostComment = () => {
   };
   const inputRef = useClickAway(handleClickAway);
 
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setWarn(false);
+    setComment(e.target.value);
+  };
+
   const handleCommentSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!comment) {
@@ -91,7 +96,7 @@ const PostComment = () => {
               width='538px'
               height='48px'
               underline={true}
-              onChange={(e) => setComment(e.target.value)}
+              onChange={handleInputChange}
             />
             {warn ? <Warning>댓글을 입력해주세요.</Warning> : ''}
           </FlexColumn>

--- a/src/pages/DetailPage/PostComment/index.tsx
+++ b/src/pages/DetailPage/PostComment/index.tsx
@@ -1,19 +1,37 @@
 import { useSelectedComment } from './useSelectedComment';
+import { FlexColumn } from './StyledPostComment';
 import { useState } from 'react';
 import axios from 'axios';
+import { useParams } from 'react-router-dom';
 import CommentItem from '@/components/Comment';
 import theme from '@/styles/theme';
 import Input from '@/components/Input';
 import Button from '@/components/Button';
+import { useDispatch } from '@/store';
+import { getPostDetail } from '@/slices/postDetail';
+import { Warning } from '@/components/Sign/SignStyle';
+import useClickAway from '@/hooks/useClickAway';
 
 const PostComment = () => {
   const postDetailComment = useSelectedComment();
   const [comment, setComment] = useState('');
+  const [warn, setWarn] = useState(false);
+  const { postId } = useParams();
+  const dispatch = useDispatch();
+
+  const handleClickAway = () => {
+    setWarn(false);
+  };
+  const inputRef = useClickAway(handleClickAway);
 
   const handleCommentSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!comment) {
+      setWarn(true);
+      return;
+    }
     try {
-      axios({
+      await axios({
         url: 'https://kdt.frontend.5th.programmers.co.kr:5003/comments/create',
         method: 'POST',
         data: {
@@ -22,12 +40,14 @@ const PostComment = () => {
             voteArray: ['한식', '중식', '일식', '양식'],
             content: comment,
           }),
-          postId: '6592c80a2a48542ca963b86d',
+          postId,
         },
         headers: {
-          Authorization: '',
+          Authorization: `Bearer ${localStorage.getItem('auth-token')}`,
         },
       });
+
+      dispatch(getPostDetail({ postId }));
     } catch (e) {
       alert(e);
     }
@@ -62,15 +82,19 @@ const PostComment = () => {
             alignItems: 'center',
             justifyContent: 'space-between',
           }}>
-          <Input
-            bordertype='filled'
-            placeholder='플레이스 홀더 텍스트'
-            fontType='body2'
-            width='538px'
-            height='48px'
-            underline={true}
-            onChange={(e) => setComment(e.target.value)}
-          />
+          <FlexColumn>
+            <Input
+              ref={inputRef as React.RefObject<HTMLInputElement>}
+              bordertype={warn ? 'error' : 'filled'}
+              placeholder='플레이스 홀더 텍스트'
+              fontType='body2'
+              width='538px'
+              height='48px'
+              underline={true}
+              onChange={(e) => setComment(e.target.value)}
+            />
+            {warn ? <Warning>댓글을 입력해주세요.</Warning> : ''}
+          </FlexColumn>
           <Button
             event='enabled'
             size='regular'

--- a/src/pages/DetailPage/PostVote/index.tsx
+++ b/src/pages/DetailPage/PostVote/index.tsx
@@ -4,6 +4,7 @@ import Card from '@/components/Card';
 import Input from '@/components/Input';
 import Button from '@/components/Button';
 import Text from '@/components/Text';
+import ScrollBar from '@/components/ScrollBar';
 
 const VoteTitleWrapper = styled.div`
   display: flex;
@@ -30,37 +31,39 @@ const PostVote = () => {
 
   return (
     <Card width='44.375rem' height='31.25rem' shadowType='large'>
-      <VoteTitleWrapper>
-        <Text
-          tagType='span'
-          fontType='h3'
-          colorType='black'
-          style={{ margin: '1rem 0' }}>
-          {voteTitle}
-        </Text>
-        <Text tagType='span' fontType='body2' colorType='black'>
-          0명 투표
-        </Text>
-      </VoteTitleWrapper>
-      <InputWrapper>
-        {voteArray.map((vote: string, index: number) => (
-          <Input
-            key={index}
-            placeholder={vote}
-            bordertype='enabled'
-            readOnly={true}
-            style={{ marginBottom: '1.5rem', width: '466px', height: '48px' }}
-          />
-        ))}
-      </InputWrapper>
-      <ButtonWrapper>
-        <Button event='enabled' styleType='primary' size='wide'>
-          투표 하기
-        </Button>
-        <Button event='enabled' styleType='ghost' size='wide'>
-          결과 보기
-        </Button>
-      </ButtonWrapper>
+      <ScrollBar>
+        <VoteTitleWrapper>
+          <Text
+            tagType='span'
+            fontType='h3'
+            colorType='black'
+            style={{ margin: '1rem 0' }}>
+            {voteTitle}
+          </Text>
+          <Text tagType='span' fontType='body2' colorType='black'>
+            0명 투표
+          </Text>
+        </VoteTitleWrapper>
+        <InputWrapper>
+          {voteArray.map((vote: string, index: number) => (
+            <Input
+              key={index}
+              placeholder={vote}
+              bordertype='enabled'
+              readOnly={true}
+              style={{ marginBottom: '1.5rem', width: '466px', height: '48px' }}
+            />
+          ))}
+        </InputWrapper>
+        <ButtonWrapper>
+          <Button event='enabled' styleType='primary' size='wide'>
+            투표 하기
+          </Button>
+          <Button event='enabled' styleType='ghost' size='wide'>
+            결과 보기
+          </Button>
+        </ButtonWrapper>
+      </ScrollBar>
     </Card>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,8 +9,9 @@ const Index = () => {
 
   const handleStart = (e: React.MouseEvent) => {
     e.preventDefault();
-    const token = localStorage.getItem('auth-token');
-    navigate(token ? '/home' : '/sign');
+    // const token = localStorage.getItem('auth-token'); // 나중에 바낄지도 모름
+    // navigate(token ? '/home' : '/sign');
+    navigate('/home');
   };
 
   return (

--- a/src/pages/mainPage/index.tsx
+++ b/src/pages/mainPage/index.tsx
@@ -60,12 +60,8 @@ const Main = () => {
 
   useEffect(() => {
     const token = localStorage.getItem('auth-token');
-    if (!token) {
-      alert('로그인이 필요한 서비스 입니다.');
-      navigate('/sign');
-    } else {
-      dispatch(getMyInfo({ token }));
-    }
+    if (!token) return;
+    dispatch(getMyInfo({ token }));
   }, [navigate, dispatch]);
 
   return (

--- a/src/slices/postList/thunks.ts
+++ b/src/slices/postList/thunks.ts
@@ -9,7 +9,7 @@ export interface GetPostsByChannelIdParams {
 }
 
 export const getPostListByChannelId = createAsyncThunk(
-  `${name}/getPostsByChannelId`,
+  `${name}/getPostListByChannelId`,
   async ({ channelId, offset, limit }: GetPostsByChannelIdParams) => {
     const queries = paginationClaculator(offset, limit);
 


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works
### Explain
- 인덱스 페이지에서 바로 홈으로 가도록 라우팅처리하였습니다. (미인증 사용자도 홈 바로이용가능)
- detail page 의 댓글 기능을 구현했습니다.
- detail page 의 카드에 스크롤을 추가하였습니다.!

### Refer

![화면 캡처 2024-01-04 143048](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/5140a582-ed79-46fe-ba5a-dde11107e4af)
### 댓글
![화면 캡처 2024-01-04 143112](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/6dd8ba9f-29d6-43b5-9e8e-8fc174fec81d)
![화면 캡처 2024-01-04 143124](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/52bb63f5-3f9f-49cf-9c39-185360f6c0a5)
## 빈값 오류
![화면 캡처 2024-01-04 143135](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/7f65d9e8-a94a-46d9-a4db-9a1d7e24958d)

close #103 
