### PR TITLE
[FIX] 알림 초기 값으로 1이 보였다가 사라지는 현상 수정

### DIFF
--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -51,7 +51,7 @@ const Main = () => {
   const postList = keyword ? searchedPosts : posts;
   const postSnippetList = postListToPostSnippetList(postList);
   const { paginationedPostList, totalPage, currentPage, handlePageChange } =
-    usePagination(postSnippetList);
+    usePagination(postSnippetList, 9);
 
   const getChannelTitle = () => {
     if (channelStatus === 'loading') return '로딩중';

--- a/src/slices/notification/index.ts
+++ b/src/slices/notification/index.ts
@@ -6,23 +6,10 @@ import {
 } from './thunk';
 import { InitialState } from './notificationType';
 import { createSlice, isAnyOf } from '@reduxjs/toolkit';
-import { Comment, Notification, User, Follow } from '@/types/APIResponseTypes';
+import { Notification } from '@/types/APIResponseTypes';
 
 const initialState: InitialState = {
-  notifications: [
-    {
-      seen: false,
-      _id: '',
-      author: {} as User,
-      user: '',
-      post: '',
-      follow: {} as Follow,
-      comment: {} as Comment,
-      message: '',
-      createdAt: '',
-      updatedAt: '',
-    },
-  ],
+  notifications: [],
   isLoading: false,
 };
 const notificationSlice = createSlice({


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works
## 1-1.ISSUE_KEY:  #198
### Explain
초기값을 빈배열로 시작하도록하여, 버그해결
- 페이지네이션 9 개로 줄임

close #198 
