### PR TITLE
[FIX]update페이지 서버데이터의 channelId로 변경

### DIFF
--- a/src/components/Post/Detail/Content/index.tsx
+++ b/src/components/Post/Detail/Content/index.tsx
@@ -14,7 +14,7 @@ import theme from '@/styles/theme';
 const PostContent = () => {
   const postDetailContent = useSelectedPostDetail();
   const navigate = useNavigate();
-  const { postId, channelId } = useParams();
+  const { postId } = useParams();
   const myInfo = useSelectedMyInfo();
   const { author, createdAt } = postDetailContent;
 
@@ -31,7 +31,7 @@ const PostContent = () => {
   const handlePostEdit = () => {
     const isConfirm = window.confirm('수정하시겠습니까?');
     if (!isConfirm) return;
-    navigate(`/update/${channelId}/${postId}`);
+    navigate(`/update/${postId}`);
   };
   const handlePostDelete = async () => {
     const isConfirm = window.confirm('게시글을 삭제하시겠습니까?');

--- a/src/components/layout/Header/NotificationCardBell/index.tsx
+++ b/src/components/layout/Header/NotificationCardBell/index.tsx
@@ -49,9 +49,7 @@ const NotificationCardBell = () => {
     },
   );
 
-  const ref = useClickAway((e: MouseEvent | TouchEvent) => {
-    const { tagName } = e.target as HTMLElement;
-    if (tagName === 'path' || tagName === 'svg') return;
+  const ref = useClickAway(() => {
     setToggleNotification(false);
   });
 

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -79,9 +79,7 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
     setFocus(!focus);
   });
 
-  const menuRef = useClickAway((e: MouseEvent | TouchEvent) => {
-    const { tagName } = e.target as HTMLElement;
-    if (tagName === 'IMG') return;
+  const menuRef = useClickAway(() => {
     setShowMenu(false);
   });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,7 +36,7 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       {
-        path: '/update/:channelId/:postId',
+        path: '/update/:postId',
         element: (
           <ProtectedRoute>
             <PostUpdatePage />

--- a/src/pages/UpdatePage/index.tsx
+++ b/src/pages/UpdatePage/index.tsx
@@ -15,7 +15,7 @@ import { FormType } from '@/pages/UpdatePage/type';
 import { useSelectedVote } from '@/hooks/useSelectedVote';
 
 const PostUpdatePage = () => {
-  const { channelId, postId } = useParams();
+  const { postId } = useParams();
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
@@ -23,7 +23,8 @@ const PostUpdatePage = () => {
     dispatch(getPostDetail({ postId }));
   }, [dispatch, postId]);
 
-  const { image, imagePublicId, title } = useSelectedPostDetail();
+  const { image, imagePublicId, title, channel } = useSelectedPostDetail();
+  const channelId = channel._id;
   const serverData = JSON.parse(title);
   const postDetailVote = useSelectedVote();
   const isVoteEmpty = postDetailVote.length === 0;


### PR DESCRIPTION
전체페이지에서 게시글을 선택한 후 수정하기를 하면
채널 지정이 안되거나 맞지 않는 채널이 지정되는 오류가 있어 수정했습니다.

- router에서 channelId를 가져오는 것이 아닌 서버에서 가오게 변경
- updatepage 라우터 변경

추가 fix
- 알림창 로고 클릭시 닫힘
- 아바타 프로필 카드뷰 이미지 클릭시 동일하게 안닫혀서 고침

변경사항 별로 없어서 같이 pr날립니다.