### PR TITLE
[FEAT] 유저 페이지 페이지네이션 적용

### DIFF
--- a/src/components/User/UserPostList/index.tsx
+++ b/src/components/User/UserPostList/index.tsx
@@ -4,10 +4,12 @@ import Text from '@/components/common/Text';
 import { useDispatch } from '@/store';
 import { getUser } from '@/slices/user';
 import PostCard from '@/components/Main/PostCard';
+import Pagination from '@/components/Main/Pagination';
 import { postListToPostSnippetList } from '@/slices/postList/utils';
 import { useSelectedPostList } from '@/hooks/useSelectedPostList';
 import { getPostListByUserId } from '@/slices/postList/thunks';
 import { useSelectedUser } from '@/hooks/useSelectedUser';
+import { usePagination } from '@/hooks/usePagination';
 import theme from '@/styles/theme';
 
 const UserPostList = () => {
@@ -15,6 +17,10 @@ const UserPostList = () => {
   const { userId } = useParams();
   const currentUser = useSelectedUser();
   const postList = useSelectedPostList();
+
+  const postSnippetList = postListToPostSnippetList(postList);
+  const { paginatedPostList, totalPage, currentPage, handlePageChange } =
+    usePagination(postSnippetList, 4);
 
   useEffect(() => {
     if (!userId) return;
@@ -28,7 +34,6 @@ const UserPostList = () => {
 
   if (!currentUser) return null;
   const { fullName } = currentUser;
-  const postSnippetList = postListToPostSnippetList(postList);
 
   return (
     <>
@@ -42,8 +47,9 @@ const UserPostList = () => {
         colorNumber={theme.isDark ? '200' : '400'}>
         님의 최근 게시글
       </Text>
-      <PostCard.Group style={{ width: '80vw', margin: '2rem 0', maxWidth: '1440px' }}>
-        {postSnippetList.length === 0 ? (
+      <PostCard.Group
+        style={{ width: '80vw', margin: '2rem 0', maxWidth: '1440px' }}>
+        {paginatedPostList.length === 0 ? (
           <Text
             tagType='span'
             fontType='h4'
@@ -52,11 +58,16 @@ const UserPostList = () => {
             게시글이 존재하지 않습니다.
           </Text>
         ) : (
-          postSnippetList.map((post) => {
+          paginatedPostList.map((post) => {
             return <PostCard key={post._id} post={post} />;
           })
         )}
       </PostCard.Group>
+      <Pagination
+        page={currentPage}
+        totalPage={totalPage}
+        onPageChange={handlePageChange}
+      />
     </>
   );
 };


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works
## 1-1.ISSUE_KEY: #231 
유저페이지의 postlist 페이지네이션을 적용했습니다.

### Refer
![화면 캡처 2024-01-12 111747](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/45db6672-ac6a-4713-9c7b-1e2bab2417d4)
![화면 캡처 2024-01-12 111736](https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/137467530/c5415e1b-92e8-4fe9-b457-be0d46c18c24)


close #231 