### PR TITLE
[Feat] 툴팁 컴포넌트 제작 및 적용

### DIFF
--- a/src/components/User/GrassTable/index.tsx
+++ b/src/components/User/GrassTable/index.tsx
@@ -1,6 +1,7 @@
 import { GrassWrapper, GrassItem } from '@/components/User/GrassTable/style';
 import { useSelectedUser } from '@/hooks/useSelectedUser';
 import { LightnessType } from '@/components/User/GrassTable/type';
+import Tooltip from '@/components/Common/Tooltip';
 
 const GrassTable = () => {
   const currentUser = useSelectedUser();
@@ -8,9 +9,9 @@ const GrassTable = () => {
   const month = new Date().getMonth();
 
   const lastDayOfMonth = new Date(year, month + 1, 0).getDate();
-  const grass = Array.from(
+  const grass: { lightness: LightnessType; postNumber: number }[] = Array.from(
     { length: lastDayOfMonth },
-    (): LightnessType => 100,
+    () => ({ lightness: 100, postNumber: 0 }),
   );
 
   currentUser?.posts.forEach((post) => {
@@ -22,20 +23,26 @@ const GrassTable = () => {
     const currentYear = new Date().getFullYear();
     const currentMonth = new Date().getMonth();
 
-    if (
-      postYear === currentYear &&
-      postMonth === currentMonth &&
-      grass[postDay] < 500
-    ) {
-      grass[postDay] += 100;
+    if (postYear === currentYear && postMonth === currentMonth) {
+      if (grass[postDay].lightness + 100 < 500) {
+        grass[postDay].lightness += 100;
+      }
+      grass[postDay].postNumber += 1;
     }
   });
 
   return (
     <GrassWrapper>
       {grass &&
-        grass.map((lightness, i) => (
-          <GrassItem key={i} lightness={lightness} />
+        grass.map((data, i) => (
+          <Tooltip
+            key={i}
+            direction='bottom'
+            message={`게시물: ${data.postNumber}`}
+            hasArrow={true}
+            type='hover'>
+            <GrassItem lightness={data.lightness} />
+          </Tooltip>
         ))}
     </GrassWrapper>
   );

--- a/src/components/User/UserInfo/index.tsx
+++ b/src/components/User/UserInfo/index.tsx
@@ -11,16 +11,37 @@ import { useDispatch } from '@/store';
 import { getUser } from '@/slices/user';
 import { useSelectedFollowData } from '@/hooks/useSelectedFollowData';
 import { useSelectedUser } from '@/hooks/useSelectedUser';
+import Tooltip from '@/components/Common/Tooltip';
+import { useSelectedUserList } from '@/hooks/useSelectedUserList';
+import { getUserList } from '@/slices/userList/thunk';
 
 const UserInfo = () => {
   const dispatch = useDispatch();
   const { userId } = useParams();
   const { isFollower, isFollowing } = useSelectedFollowData();
+
   useEffect(() => {
     if (userId) {
       dispatch(getUser({ userId }));
     }
   }, [dispatch, userId, isFollower, isFollowing]);
+
+  useEffect(() => {
+    dispatch(getUserList());
+  }, [dispatch]);
+  const userList = useSelectedUserList();
+
+  const getFullNames = (userIds: string[]) => {
+    return userIds
+      .map((userId) => {
+        const user = userList.find((user) => {
+          return user._id === userId;
+        });
+
+        return user ? user.fullName : 'Unknown User';
+      })
+      .join(', ');
+  };
 
   const currentUser = useSelectedUser();
   if (!currentUser) return null;
@@ -39,12 +60,28 @@ const UserInfo = () => {
             {username || '한줄 소개가 없습니다'}
           </Text>
           <UserButtonContainer>
-            <Button size='regular' styleType='ghost'>
-              {followers.length} 팔로워
-            </Button>
-            <Button size='regular' styleType='ghost'>
-              {following.length} 팔로잉
-            </Button>
+            <Tooltip
+              direction='bottom'
+              message={getFullNames(followers.map((follower) => follower.user))}
+              hasArrow={true}
+              type='click'>
+              <a>
+                <Button size='regular' styleType='ghost'>
+                  {followers.length} 팔로워
+                </Button>
+              </a>
+            </Tooltip>
+            <Tooltip
+              direction='bottom'
+              message={getFullNames(following.map((followee) => followee.user))}
+              hasArrow={true}
+              type='click'>
+              <a>
+                <Button size='regular' styleType='ghost'>
+                  {following.length} 팔로잉
+                </Button>
+              </a>
+            </Tooltip>
             <Button size='regular' styleType='ghost'>
               {posts.length} 포스트
             </Button>

--- a/src/components/common/Tooltip/TooltipArrow.tsx
+++ b/src/components/common/Tooltip/TooltipArrow.tsx
@@ -1,0 +1,54 @@
+import styled, { css } from 'styled-components';
+
+type TooltipDirection = 'top' | 'bottom' | 'left' | 'right';
+
+interface TooltipArrowProps {
+  direction: TooltipDirection;
+}
+
+const TooltipArrow = styled.div<TooltipArrowProps>`
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 5px;
+  background-color: transparent;
+
+  ${({ direction }) => {
+    const directionStyles = {
+      top: css`
+        left: 50%;
+        top: 100%;
+        transform: translateX(-50%) translateY(-0%);
+        border-color: #faf7e8 transparent transparent transparent;
+      `,
+      bottom: css`
+        left: 50%;
+        bottom: 100%;
+        transform: translateX(-50%) translateY(0%);
+        border-color: transparent transparent #faf7e8 transparent; /* 삼각형 색상 조절 */
+      `,
+      left: css`
+        top: 50%;
+        left: 100%;
+        transform: translateY(-50%) translateX(0%);
+        border-color: transparent transparent transparent #faf7e8; /* 삼각형 색상 조절 */
+      `,
+      right: css`
+        top: 50%;
+        right: 100%;
+        transform: translateY(-50%) translateX(0%);
+        border-color: transparent #faf7e8 transparent transparent; /* 삼각형 색상 조절 */
+      `,
+    };
+
+    return css`
+      ${directionStyles[direction]}
+      border-width: 0.5rem;
+      content: '';
+      position: absolute;
+    `;
+  }}
+`;
+
+export default TooltipArrow;

--- a/src/components/common/Tooltip/TooltipArrow.tsx
+++ b/src/components/common/Tooltip/TooltipArrow.tsx
@@ -26,19 +26,19 @@ const TooltipArrow = styled.div<TooltipArrowProps>`
         left: 50%;
         bottom: 100%;
         transform: translateX(-50%) translateY(0%);
-        border-color: transparent transparent #faf7e8 transparent; /* 삼각형 색상 조절 */
+        border-color: transparent transparent #faf7e8 transparent;
       `,
       left: css`
         top: 50%;
         left: 100%;
         transform: translateY(-50%) translateX(0%);
-        border-color: transparent transparent transparent #faf7e8; /* 삼각형 색상 조절 */
+        border-color: transparent transparent transparent #faf7e8;
       `,
       right: css`
         top: 50%;
         right: 100%;
         transform: translateY(-50%) translateX(0%);
-        border-color: transparent #faf7e8 transparent transparent; /* 삼각형 색상 조절 */
+        border-color: transparent #faf7e8 transparent transparent;
       `,
     };
 

--- a/src/components/common/Tooltip/TooltipArrow.tsx
+++ b/src/components/common/Tooltip/TooltipArrow.tsx
@@ -1,6 +1,5 @@
 import styled, { css } from 'styled-components';
-
-type TooltipDirection = 'top' | 'bottom' | 'left' | 'right';
+import { TooltipDirection } from '@/components/Common/Tooltip/type';
 
 interface TooltipArrowProps {
   direction: TooltipDirection;

--- a/src/components/common/Tooltip/index.tsx
+++ b/src/components/common/Tooltip/index.tsx
@@ -1,62 +1,13 @@
 import React, { useEffect, useRef } from 'react';
-import styled from 'styled-components';
 import useHover from '@/hooks/useHover';
+import TooltipContainer, {
+  TooltipContent,
+  TooltipDirection,
+} from '@/components/common/Tooltip/style';
 import TooltipArrow from '@/components/common/Tooltip/TooltipArrow';
 
-const TooltipContainer = styled.div`
-  position: relative;
-  cursor: pointer;
-  width: fit-content;
-`;
-
-const getBoxShadow = (direction: TooltipDirection) => {
-  const shadowCommon = '12px rgba(0, 0, 0, 0.2)';
-  switch (direction) {
-    case 'top':
-      return `0 5px ${shadowCommon}`;
-    case 'bottom':
-      return `0 -5px ${shadowCommon}`;
-    case 'left':
-      return `10px 2px ${shadowCommon}`;
-    case 'right':
-      return `-5px 2px ${shadowCommon}`;
-    default:
-      return 'none';
-  }
-};
-
-const TooltipContent = styled.span<{
-  direction: TooltipDirection;
-}>`
-  position: absolute;
-  z-index: 10;
-  border-radius: 0.375rem;
-  background-color: #faf7e8;
-  padding: 10px;
-  text-align: center;
-  color: #000;
-  width: 100px;
-  max-width: 300px;
-  font-size: 14px;
-  line-height: 1.5;
-  box-shadow: ${({ direction }) => getBoxShadow(direction)};
-
-  ${({ direction }) => {
-    const directionStyles = {
-      top: 'bottom: 100%; left: 50%; transform: translateX(-50%) translateY(-0.5rem); margin-bottom:12px;',
-      bottom:
-        'top: 100%; left: 50%; transform: translateX(-50%) translateY(0.5rem); margin-top:12px;',
-      left: 'top: 50%; right: 100%; transform: translateY(-50%) translateX(-0.5rem);margin-right:12px;',
-      right:
-        'top: 50%; left: 100%; transform: translateY(-50%) translateX(0.5rem); margin-left:12px;',
-    };
-
-    return directionStyles[direction];
-  }}
-`;
-
-type TooltipDirection = 'top' | 'bottom' | 'left' | 'right';
 type TooltipType = 'click' | 'focus' | 'hover';
+
 interface TooltipProps {
   message: string;
   type?: TooltipType;
@@ -65,13 +16,13 @@ interface TooltipProps {
   children: React.ReactNode;
 }
 
-const Tooltip: React.FC<TooltipProps> = ({
+const Tooltip = ({
   type,
   hasArrow,
   message,
   direction,
   children,
-}) => {
+}: TooltipProps) => {
   const [ref, isHovered] = useHover();
   const [show, setShow] = React.useState(false);
   const tooltipRef = useRef<HTMLSpanElement | null>(null);

--- a/src/components/common/Tooltip/index.tsx
+++ b/src/components/common/Tooltip/index.tsx
@@ -1,20 +1,10 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, PropsWithChildren } from 'react';
 import useHover from '@/hooks/useHover';
 import TooltipContainer, {
   TooltipContent,
-  TooltipDirection,
 } from '@/components/common/Tooltip/style';
 import TooltipArrow from '@/components/common/Tooltip/TooltipArrow';
-
-type TooltipType = 'click' | 'focus' | 'hover';
-
-interface TooltipProps {
-  message: string;
-  type?: TooltipType;
-  direction: TooltipDirection;
-  hasArrow: boolean;
-  children: React.ReactNode;
-}
+import { TooltipProps } from '@/components/common/Tooltip/type';
 
 const Tooltip = ({
   type,
@@ -22,7 +12,7 @@ const Tooltip = ({
   message,
   direction,
   children,
-}: TooltipProps) => {
+}: PropsWithChildren<TooltipProps>) => {
   const [ref, isHovered] = useHover();
   const [show, setShow] = React.useState(false);
   const tooltipRef = useRef<HTMLSpanElement | null>(null);

--- a/src/components/common/Tooltip/index.tsx
+++ b/src/components/common/Tooltip/index.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import useHover from '@/hooks/useHover';
+import TooltipArrow from '@/components/common/Tooltip/TooltipArrow';
+
+const TooltipContainer = styled.div`
+  position: relative;
+  cursor: pointer;
+  width: fit-content;
+`;
+
+const getBoxShadow = (direction: TooltipDirection) => {
+  const shadowCommon = '12px rgba(0, 0, 0, 0.2)';
+  switch (direction) {
+    case 'top':
+      return `0 5px ${shadowCommon}`;
+    case 'bottom':
+      return `0 -5px ${shadowCommon}`;
+    case 'left':
+      return `10px 2px ${shadowCommon}`;
+    case 'right':
+      return `-5px 2px ${shadowCommon}`;
+    default:
+      return 'none';
+  }
+};
+
+const TooltipContent = styled.span<{
+  direction: TooltipDirection;
+}>`
+  position: absolute;
+  z-index: 10;
+  border-radius: 0.375rem;
+  background-color: #faf7e8;
+  padding: 10px;
+  text-align: center;
+  color: #000;
+  width: 100px;
+  max-width: 300px;
+  font-size: 14px;
+  line-height: 1.5;
+  box-shadow: ${({ direction }) => getBoxShadow(direction)};
+
+  ${({ direction }) => {
+    const directionStyles = {
+      top: 'bottom: 100%; left: 50%; transform: translateX(-50%) translateY(-0.5rem); margin-bottom:12px;',
+      bottom:
+        'top: 100%; left: 50%; transform: translateX(-50%) translateY(0.5rem); margin-top:12px;',
+      left: 'top: 50%; right: 100%; transform: translateY(-50%) translateX(-0.5rem);margin-right:12px;',
+      right:
+        'top: 50%; left: 100%; transform: translateY(-50%) translateX(0.5rem); margin-left:12px;',
+    };
+
+    return directionStyles[direction];
+  }}
+`;
+
+type TooltipDirection = 'top' | 'bottom' | 'left' | 'right';
+type TooltipType = 'click' | 'focus' | 'hover';
+interface TooltipProps {
+  message: string;
+  type?: TooltipType;
+  direction: TooltipDirection;
+  hasArrow: boolean;
+  children: React.ReactNode;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({
+  type,
+  hasArrow,
+  message,
+  direction,
+  children,
+}) => {
+  const [ref, isHovered] = useHover();
+  const [show, setShow] = React.useState(false);
+  const tooltipRef = useRef<HTMLSpanElement | null>(null);
+
+  useEffect(() => {
+    if (!type) {
+      return;
+    }
+    const handleEvent = () => {
+      setShow((prevShow) => !prevShow);
+    };
+
+    const targetElement = ref.current;
+
+    if (targetElement) {
+      if (type === 'hover') {
+        setShow(isHovered);
+      } else {
+        targetElement.addEventListener(type, handleEvent);
+      }
+
+      return () => {
+        targetElement.removeEventListener(type, handleEvent);
+      };
+    }
+  }, [type, isHovered, ref]);
+
+  return (
+    <TooltipContainer>
+      {React.cloneElement(React.Children.only(children) as React.ReactElement, {
+        ref,
+      })}
+      {show && (
+        <TooltipContent
+          ref={tooltipRef}
+          direction={direction}
+          onAnimationEnd={() => {
+            if (!show) {
+              tooltipRef.current?.remove();
+              tooltipRef.current = null;
+            }
+          }}>
+          {message.split(',').map((item, index) => (
+            <React.Fragment key={index}>
+              {item}
+              <br />
+            </React.Fragment>
+          ))}
+          {hasArrow && <TooltipArrow direction={direction} />}
+        </TooltipContent>
+      )}
+    </TooltipContainer>
+  );
+};
+
+export default Tooltip;

--- a/src/components/common/Tooltip/style.tsx
+++ b/src/components/common/Tooltip/style.tsx
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+
+export const TooltipContainer = styled.div`
+  position: relative;
+  cursor: pointer;
+  width: fit-content;
+`;
+
+export const TooltipContent = styled.span<{ direction: TooltipDirection }>`
+  position: absolute;
+  z-index: 10;
+  border-radius: 0.375rem;
+  background-color: #faf7e8;
+  padding: 10px;
+  text-align: center;
+  color: #000;
+  width: 100px;
+  max-width: 300px;
+  font-size: 14px;
+  line-height: 1.5;
+  box-shadow: ${({ direction }) => getBoxShadow(direction)};
+
+  ${({ direction }) => {
+    const directionStyles = {
+      top: 'bottom: 100%; left: 50%; transform: translateX(-50%) translateY(-0.5rem); margin-bottom:12px;',
+      bottom:
+        'top: 100%; left: 50%; transform: translateX(-50%) translateY(0.5rem); margin-top:12px;',
+      left: 'top: 50%; right: 100%; transform: translateY(-50%) translateX(-0.5rem);margin-right:12px;',
+      right:
+        'top: 50%; left: 100%; transform: translateY(-50%) translateX(0.5rem); margin-left:12px;',
+    };
+
+    return directionStyles[direction];
+  }}
+`;
+
+export const getBoxShadow = (direction: TooltipDirection) => {
+  const shadowCommon = '12px rgba(0, 0, 0, 0.2)';
+  switch (direction) {
+    case 'top':
+      return `0 5px ${shadowCommon}`;
+    case 'bottom':
+      return `0 -5px ${shadowCommon}`;
+    case 'left':
+      return `10px 2px ${shadowCommon}`;
+    case 'right':
+      return `-5px 2px ${shadowCommon}`;
+    default:
+      return 'none';
+  }
+};
+
+type TooltipDirection = 'top' | 'bottom' | 'left' | 'right';
+
+export default TooltipContainer;

--- a/src/components/common/Tooltip/style.tsx
+++ b/src/components/common/Tooltip/style.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { TooltipDirection } from '@/components/Common/Tooltip/type';
 
 export const TooltipContainer = styled.div`
   position: relative;
@@ -49,7 +50,5 @@ export const getBoxShadow = (direction: TooltipDirection) => {
       return 'none';
   }
 };
-
-type TooltipDirection = 'top' | 'bottom' | 'left' | 'right';
 
 export default TooltipContainer;

--- a/src/components/common/Tooltip/type.tsx
+++ b/src/components/common/Tooltip/type.tsx
@@ -1,0 +1,9 @@
+export type TooltipDirection = 'top' | 'bottom' | 'left' | 'right';
+export type TooltipType = 'click' | 'focus' | 'hover';
+
+export interface TooltipProps {
+  message: string;
+  type?: TooltipType;
+  direction: TooltipDirection;
+  hasArrow: boolean;
+}

--- a/src/types/APIResponseTypes.ts
+++ b/src/types/APIResponseTypes.ts
@@ -6,7 +6,11 @@ export interface User {
   posts: Post[];
   likes: Like[];
   comments: string[];
-  followers: [];
+  followers: [
+    {
+      user: string;
+    },
+  ];
   following: [
     {
       _id: string;


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works
## 1-1.ISSUE_KEY: #232

### Explain
- 툴팁 컴포넌트 제작 (프롭스에 옵션이 많은 상태인데 tooltip활용 더  하는 곳이 없으면 추후 삭제 예정입니다.)
- 잔디밭 적용 칸 별로 post 갯수 렌더링 (hover)
- followers, followings 에 해당 id의 fullName 렌더링 (click)

### Refer


https://github.com/prgrms-fe-devcourse/FEDC5_NodakNodak_Noah/assets/107539614/53ca76d5-9caf-43ec-aa3e-8b4802ea9113




