### PR TITLE
[Refector] header 컴포넌트 props 대신 리덕스 활용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,12 @@
 import { Outlet } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { useEffect } from 'react';
 
-import { useDispatch, RootState } from '@/store';
-import { getChannel } from '@/slices/channel';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 
 const App = () => {
-  const channels = useSelector((state: RootState) => state.channel.channels);
-  const myInfo = useSelector((state: RootState) => state.userInfo.authUser);
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(getChannel());
-  }, [dispatch]);
   return (
     <>
-      <Header
-        channels={channels}
-        isAuth={!!localStorage.getItem('auth-token')}
-        userImage={myInfo?.image}
-      />
+      <Header />
       <Outlet />
       <Footer />
     </>

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -2,7 +2,6 @@ import { ChangeEvent, RefObject, useState, useEffect, FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Text, Card, Input, Avatar, Button } from '@/components/common';
-import HeaderProps from '@/components/layout/Header/type';
 import LogoWithFontSize from '@/components/layout/LogoWithFontSize';
 import NotificationCardBell from '@/components/layout/Header/NotificationCardBell';
 import {
@@ -13,7 +12,7 @@ import useClickAway from '@/hooks/useClickAway';
 import { useSelectedMyInfo } from '@/hooks/useSelectedMyInfo';
 
 import { useDispatch } from '@/store';
-import { setChannel } from '@/slices/channel';
+import { getChannel, setChannel } from '@/slices/channel';
 import { getNotificationArray } from '@/slices/notification/thunk';
 import {
   StyledHeaderWrapper,
@@ -27,12 +26,16 @@ import DarkModeToggle from '@/components/layout/Header/DarkModeToggle';
 import axiosInstance from '@/utils/customAxios';
 import theme from '@/styles/theme';
 import SearchIcon from '@/assets/SearchIcon';
+import { useSelectedChannels } from '@/hooks/useSelectedChannel';
 
-const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
+const Header = () => {
   const [focus, setFocus] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [showMenu, setShowMenu] = useState(false);
-  const myInfo = useSelectedMyInfo();
+
+  const channels = useSelectedChannels();
+  const { role: myRole, image: myImage, _id: myId } = useSelectedMyInfo();
+  const isAuth = !!localStorage.getItem('auth-token');
 
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -40,7 +43,7 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
   const menu = [
     '마이페이지',
     '비밀번호 변경',
-    myInfo?.role === 'Regular' ? '문의하기' : '문의함',
+    myRole === 'Regular' ? '문의하기' : '문의함',
     '로그아웃',
   ];
   const handleSearch = (e: FormEvent<HTMLFormElement>) => {
@@ -66,7 +69,7 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
     switch (item) {
       case '마이페이지': {
         setShowMenu(false);
-        navigate(`/user/${myInfo?._id}`);
+        navigate(`/user/${myId}`);
         break;
       }
       case '로그아웃': {
@@ -88,8 +91,8 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
       }
       case '비밀번호 변경': {
         setShowMenu(false);
-        navigate(`/user/${myInfo?._id}/setting/password`, {
-          state: myInfo?.image,
+        navigate(`/user/${myId}/setting/password`, {
+          state: myImage,
         });
         break;
       }
@@ -120,6 +123,10 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
     if (!token) return;
     dispatch(getNotificationArray());
   }, [dispatch, token]);
+
+  useEffect(() => {
+    dispatch(getChannel());
+  }, [dispatch]);
 
   return (
     <Card
@@ -175,7 +182,7 @@ const Header = ({ channels, isAuth, userImage }: HeaderProps) => {
             <NotificationCardBell />
             <Avatar
               size='small'
-              src={userImage}
+              src={myImage}
               onClick={handleAvatarClick}
               alt='유저네임'
             />

--- a/src/components/layout/Header/type.ts
+++ b/src/components/layout/Header/type.ts
@@ -1,9 +1,0 @@
-import { Channel } from '@/types/APIResponseTypes';
-
-interface HeaderProps {
-  channels: Pick<Channel, 'posts' | '_id' | 'name'>[];
-  isAuth: boolean;
-  userImage?: string;
-}
-
-export default HeaderProps;

--- a/src/hooks/useSelectedChannel.ts
+++ b/src/hooks/useSelectedChannel.ts
@@ -10,3 +10,6 @@ export const useSelectedChannelLoading = () =>
 
 export const useSelectedChannelStatus = () =>
   useSelector((state: RootState) => state.channel.status);
+
+export const useSelectedChannels = () =>
+  useSelector((state: RootState) => state.channel.channels);

--- a/src/hooks/useSelectedMyInfo.ts
+++ b/src/hooks/useSelectedMyInfo.ts
@@ -2,8 +2,12 @@ import { useSelector } from 'react-redux';
 
 import { RootState } from '@/store';
 
-export const useSelectedMyInfo = () =>
-  useSelector((state: RootState) => state.userInfo.authUser);
+export const useSelectedMyInfo = () => {
+  return useSelector((state: RootState) => state.userInfo.authUser);
+};
+
+export const useSelectedMyInfoStatus = () =>
+  useSelector((state: RootState) => state.userInfo.authUserStatus);
 
 export const useSelectedMyInfoLoading = () =>
   useSelector((state: RootState) => state.userInfo.isLoading);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,9 +5,9 @@ import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import ProtectedRoute from '@/components/common/ProtectedRoute';
 
+import store from '@/store';
 import App from '@/App';
 import Admin from '@/pages/AdminPage';
-import store from '@/store';
 import Main from '@/pages/MainPage';
 import Login from '@/pages/SignPage';
 import Index from '@/pages/IndexPage';

--- a/src/slices/initialState.ts
+++ b/src/slices/initialState.ts
@@ -1,0 +1,21 @@
+export const initialUser = {
+  coverImage: '',
+  image: '',
+  role: '',
+  isOnline: false,
+  posts: [],
+  likes: [],
+  comments: [],
+  followers: [{ follower: '' }],
+  following: [
+    { _id: '', user: '', follower: '', createdAt: '', updatedAt: '', __v: 0 },
+  ],
+  notifications: [],
+  messages: [],
+  _id: '',
+  fullName: '',
+  username: '',
+  email: '',
+  createdAt: '',
+  updatedAt: '',
+};

--- a/src/slices/type.ts
+++ b/src/slices/type.ts
@@ -1,0 +1,1 @@
+export type StatusType = 'idle' | 'loading' | 'succeeded' | 'failed';

--- a/src/slices/user.ts
+++ b/src/slices/user.ts
@@ -2,11 +2,13 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import axiosInstance from '@/utils/customAxios';
 import { UserInfo } from '@/slices/user/type';
+import { initialUser } from '@/slices/initialState';
 
 const initialState: UserInfo = {
-  currentUser: undefined,
-  authUser: undefined,
+  currentUser: initialUser,
+  authUser: initialUser,
   isLoading: false,
+  authUserStatus: 'loading',
 };
 
 export const getUser = createAsyncThunk(

--- a/src/slices/user/type.ts
+++ b/src/slices/user/type.ts
@@ -1,7 +1,9 @@
 import { User } from 'src/types/APIResponseTypes';
+import { StatusType } from '@/slices/type';
 
 export interface UserInfo {
-  currentUser: User | undefined;
-  authUser: User | undefined;
+  currentUser: User;
+  authUser: User;
   isLoading: boolean;
+  authUserStatus: StatusType;
 }

--- a/src/types/APIResponseTypes.ts
+++ b/src/types/APIResponseTypes.ts
@@ -6,21 +6,17 @@ export interface User {
   posts: Post[];
   likes: Like[];
   comments: string[];
-  followers: [
-    {
-      follower: string;
-    },
-  ];
-  following: [
-    {
-      _id: string;
-      user: string;
-      follower: string;
-      createdAt: string;
-      updatedAt: string;
-      __v: number;
-    },
-  ];
+  followers: {
+    follower: string;
+  }[];
+  following: {
+    _id: string;
+    user: string;
+    follower: string;
+    createdAt: string;
+    updatedAt: string;
+    __v: number;
+  }[];
   notifications: Notification[];
   messages: Message[];
   _id: string;


### PR DESCRIPTION
- [x] 커밋, PR 제목 및 라벨 등을 확인했습니다.

# 1. Works
## 1-1.ISSUE_KEY: #281 

### Explain
헤더 프롭스 대신 내부에 리덕스 상태 가져오는 처리
- user slice 에 초깃값 정의
- user 패칭 상태 타입 정의
- 튜플 타입 -> 배열 타입  으로 변경
- Header 에 필요한 selected 훅 정의

close #281 